### PR TITLE
Sort missions by created_at (#14)

### DIFF
--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -4,7 +4,11 @@ class MissionsController < ApplicationController
   before_action :find_mission, only: %i[edit update destroy]
 
   def index
-    @missions = Mission.all
+    if valid_order?(params[:order])
+      sort_missions
+    else
+      sort_missions_with_notice
+    end
   end
 
   def new
@@ -49,5 +53,25 @@ class MissionsController < ApplicationController
 
   def find_mission
     @mission = Mission.find(params[:id])
+  end
+
+  def sort_missions
+    case params[:field]
+    when 'created_at' then @missions = Mission.order(created_at: params[:order])
+    when nil then @missions = Mission.order(created_at: :DESC)
+    else sort_missions_with_notice
+    end
+  end
+
+  def valid_order?(order)
+    valid_orders = ['ASC', 'DESC', nil]
+    return true if valid_orders.include?(order)
+
+    false
+  end
+
+  def sort_missions_with_notice
+    flash.now[:notice] = t('.failure')
+    @missions = Mission.order(created_at: :DESC)
   end
 end

--- a/app/views/missions/index.html.erb
+++ b/app/views/missions/index.html.erb
@@ -1,13 +1,13 @@
 <h1><%= t('.title') %></h1>
 <%= link_to t('.link.create'), new_mission_path %>
 <%= form_tag(missions_path, method: 'get') do %>
-  <%= label_tag(:field, '排序標準：') %>
-  <%= select_tag(:field, options_for_select([['結束時間', :ended_at], ['建立時間', :created_at]], params[:field])) %>
+  <%= label_tag(:field, t('.field')) %>
+  <%= select_tag(:field, options_for_select([[Mission.human_attribute_name(:created_at), :created_at]], params[:field])) %>
   <br>
-  <%= label_tag(:order, '排序方式：') %>
-  <%= select_tag(:order, options_for_select([['升冪', :ASC], ['降冪', :DESC]], params[:order])) %>
+  <%= label_tag(:order, t('.order')) %>
+  <%= select_tag(:order, options_for_select([[t('.descending'), :DESC], [t('.ascending'), :ASC]], params[:order])) %>
   <br>
-  <%= submit_tag('排序') %>
+  <%= submit_tag(t('.submit')) %>
 <% end %>
 
 <ul>
@@ -17,9 +17,9 @@
       <%= link_to t('.link.delete'), mission_path(mission), method: :delete, data: { confirm: t('.alert.deletion') } %>
       <%= mission.title %>
       <%= mission.content %>
-      <%= l(mission.started_at, time: :default) %>
-      <%= l(mission.ended_at, time: :default) %>
-      <%= mission.created_at.strftime('%Y/%m/%d %H:%M') %>
+      <%= l(mission.started_at, time: :default) if mission.started_at %>
+      <%= l(mission.ended_at, time: :default) if mission.ended_at %>
+      <%= l(mission.created_at, time: :default) %>
     </li>
   <% end %>
 </ul>

--- a/app/views/missions/index.html.erb
+++ b/app/views/missions/index.html.erb
@@ -1,5 +1,15 @@
 <h1><%= t('.title') %></h1>
 <%= link_to t('.link.create'), new_mission_path %>
+<%= form_tag(missions_path, method: 'get') do %>
+  <%= label_tag(:field, '排序標準：') %>
+  <%= select_tag(:field, options_for_select([['結束時間', :ended_at], ['建立時間', :created_at]], params[:field])) %>
+  <br>
+  <%= label_tag(:order, '排序方式：') %>
+  <%= select_tag(:order, options_for_select([['升冪', :ASC], ['降冪', :DESC]], params[:order])) %>
+  <br>
+  <%= submit_tag('排序') %>
+<% end %>
+
 <ul>
   <% @missions.each do |mission| %>
     <li>
@@ -9,6 +19,7 @@
       <%= mission.content %>
       <%= l(mission.started_at, time: :default) %>
       <%= l(mission.ended_at, time: :default) %>
+      <%= mission.created_at.strftime('%Y/%m/%d %H:%M') %>
     </li>
   <% end %>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,12 +8,19 @@ en:
         content: Content
         started_at: Start time
         ended_at: End time
+        created_at: Created time
 
   missions:
     button: &button
       submit: Submit
     index:
       title: Mission List
+      field: "Sorting Field :"
+      order: "Sorting Way :"
+      ascending: Ascending
+      descending: Descending
+      failure: Only provide default sort settings
+      <<: *button
       link:
         create: Create
         edit: Edit

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -8,12 +8,19 @@ zh-TW:
         content: 內容
         started_at: 開始時間
         ended_at: 結束時間
+        created_at: 建立時間
 
   missions:
     button: &button
       submit: 送出
     index:
       title: 任務列表
+      field: 排序標準：
+      order: 排序方式：
+      ascending: 升冪
+      descending: 降冪
+      failure: 僅提供預設排序
+      <<: *button
       link:
         create: 新增任務
         edit: 修改

--- a/spec/feature/mission_spec.rb
+++ b/spec/feature/mission_spec.rb
@@ -26,6 +26,57 @@ RSpec.describe 'Missions List', type: :feature do
     end
   end
 
+  describe 'Sorting mission' do
+    let!(:first_mission) { create(:mission) }
+    let!(:second_mission) { create(:mission, created_at: DateTime.now + 1, ended_at: DateTime.now + 2) }
+    let!(:third_mission) { create(:mission, created_at: DateTime.now + 2, ended_at: DateTime.now + 3) }
+
+    context 'when visiting mission list' do
+      before { visit missions_path }
+
+      it_behaves_like 'a missions list page'
+      it_behaves_like 'a page that shows the missions sort by desc'
+    end
+
+    context 'when created_at order by desc' do
+      before { visit missions_path(field: :created_at, order: :DESC) }
+
+      it_behaves_like 'a missions list page'
+      it_behaves_like 'a page that shows the missions sort by desc'
+    end
+
+    context 'when created_at order by asc' do
+      before { visit missions_path(field: :created_at, order: :ASC) }
+
+      it_behaves_like 'a missions list page'
+      it_behaves_like 'a page that shows the missions sort by asc'
+    end
+
+    context 'when both field and order get unexpected params' do
+      let(:random_string) { Faker::String.random }
+      before { visit missions_path(field: :random_string, order: :random_string) }
+
+      it_behaves_like 'a missions list page'
+      it_behaves_like 'a page that shows the missions sort by desc'
+    end
+
+    context 'when only order get unexpected params' do
+      let(:random_string) { Faker::String.random }
+      before { visit missions_path(order: :random_string) }
+
+      it_behaves_like 'a missions list page'
+      it_behaves_like 'a page that shows the missions sort by desc'
+    end
+
+    context 'when only field get unexpected params' do
+      let(:random_string) { Faker::String.random }
+      before { visit missions_path(field: :random_string) }
+
+      it_behaves_like 'a missions list page'
+      it_behaves_like 'a page that shows the missions sort by desc'
+    end
+  end
+
   describe 'Adding missions' do
     let(:mission) { build(:mission) }
 

--- a/spec/support/features/shared_examples/mission.rb
+++ b/spec/support/features/shared_examples/mission.rb
@@ -4,11 +4,9 @@ shared_examples 'a missions list page' do
   it do
     is_expected.to have_content(I18n.t('missions.index.title'))
     is_expected.to have_content(I18n.t('missions.index.link.create'))
-    is_expected.to have_content('升冪')
-    is_expected.to have_content('降冪')
-    is_expected.to have_content('建立時間')
-    is_expected.to have_content('結束時間')
-    is_expected.to have_content('排序')
+    is_expected.to have_content(I18n.t('missions.index.ascending'))
+    is_expected.to have_content(I18n.t('missions.index.descending'))
+    is_expected.to have_content(Mission.human_attribute_name(:created_at))
   end
 end
 

--- a/spec/support/features/shared_examples/mission.rb
+++ b/spec/support/features/shared_examples/mission.rb
@@ -4,6 +4,11 @@ shared_examples 'a missions list page' do
   it do
     is_expected.to have_content(I18n.t('missions.index.title'))
     is_expected.to have_content(I18n.t('missions.index.link.create'))
+    is_expected.to have_content('升冪')
+    is_expected.to have_content('降冪')
+    is_expected.to have_content('建立時間')
+    is_expected.to have_content('結束時間')
+    is_expected.to have_content('排序')
   end
 end
 
@@ -15,5 +20,21 @@ shared_examples 'a page that shows the missions' do
     is_expected.to have_content(mission.content)
     is_expected.to have_content(mission.started_at.strftime('%Y/%m/%d %H:%M'))
     is_expected.to have_content(mission.ended_at.strftime('%Y/%m/%d %H:%M'))
+  end
+end
+
+shared_examples 'a page that shows the missions sort by desc' do
+  it 'shows the mission' do
+    is_expected.to have_selector('ul > li:nth-child(1)', text: third_mission.title)
+    is_expected.to have_selector('ul > li:nth-child(2)', text: second_mission.title)
+    is_expected.to have_selector('ul > li:nth-child(3)', text: first_mission.title)
+  end
+end
+
+shared_examples 'a page that shows the missions sort by asc' do
+  it 'shows the mission' do
+    is_expected.to have_selector('ul > li:nth-child(1)', text: first_mission.title)
+    is_expected.to have_selector('ul > li:nth-child(2)', text: second_mission.title)
+    is_expected.to have_selector('ul > li:nth-child(3)', text: third_mission.title)
   end
 end


### PR DESCRIPTION
## Added
* Add created_at and sort_link in view (#14) (#25)
  * Add sorting translation file for i18n
  * Fix view for i18n
* Add sorting feature for sorting by created_at (#14) (#25)
* Add feature spec for sorting (#14) (#25)
  * Fix spec for i18n