### PR TITLE
Add validation & specs for model `Mission` (#15)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - "spec/feature/*"
+    - "spec/models/*"
 
 Style/Documentation:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -50,5 +50,6 @@ group :test do
   gem 'faker', '~> 2.18'
   gem 'rspec-rails', '~> 5.0'
   gem 'selenium-webdriver'
+  gem 'shoulda-matchers', '~> 4.5'
   gem 'webdrivers'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -265,6 +267,7 @@ DEPENDENCIES
   rubocop-rails (~> 2.10.1)
   sass-rails (>= 6)
   selenium-webdriver
+  shoulda-matchers (~> 4.5)
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/models/mission.rb
+++ b/app/models/mission.rb
@@ -1,4 +1,17 @@
 # frozen_string_literal: true
 
 class Mission < ApplicationRecord
+  validates :title, presence: true, length: { maximum: 50 }
+  validates :content, presence: true
+  validate :validate_end_time_after_start_time
+
+  private
+
+  def validate_end_time_after_start_time
+    return if started_at.blank? || ended_at.blank?
+    return if started_at < ended_at
+
+    error_message = I18n.t('activerecord.errors.models.mission.attributes.ended_at.before_start_time')
+    errors.add(:ended_at, error_message)
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,17 @@ en:
         started_at: Start time
         ended_at: End time
         created_at: Created time
+    errors:
+      models:
+        mission:
+          attributes:
+            ended_at:
+              before_start_time: must be after Start time
+            title:
+              blank: can't be blank.
+              too_long: must be less than 50 characters
+            content:
+              blank: can't be blank.
 
   missions:
     button: &button

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -9,6 +9,17 @@ zh-TW:
         started_at: 開始時間
         ended_at: 結束時間
         created_at: 建立時間
+    errors:
+      models:
+        mission:
+          attributes:
+            ended_at:
+              before_start_time: 必須晚於開始時間
+            title:
+              blank: 是必填欄位
+              too_long: 必須小於 50 字
+            content:
+              blank: 是必填欄位
 
   missions:
     button: &button

--- a/spec/models/mission_spec.rb
+++ b/spec/models/mission_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Mission, type: :model do
+  let(:title_blank_error) { I18n.t('activerecord.errors.models.mission.attributes.title.blank') }
+  let(:title_too_long_error) { I18n.t('activerecord.errors.models.mission.attributes.title.too_long') }
+  let(:content_blank_error) { I18n.t('activerecord.errors.models.mission.attributes.content.blank') }
+
+  it { is_expected.to validate_presence_of(:title).with_message(title_blank_error) }
+  it { is_expected.to validate_length_of(:title).is_at_most(50).with_message(title_too_long_error) }
+  it { is_expected.to validate_presence_of(:content).with_message(content_blank_error) }
+
+  describe '#ended_at validation' do
+    context 'When #ended_at is bigger than #started_at' do
+      subject(:mission) { build(:mission) }
+
+      it { is_expected.to be_valid }
+    end
+
+    context 'When #ended_at is less than #started_at' do
+      subject(:mission) { build(:mission, started_at: DateTime.now + 1, ended_at: DateTime.now) }
+      let(:error_message) { I18n.t('activerecord.errors.models.mission.attributes.ended_at.before_start_time') }
+
+      before { mission.save }
+
+      it { is_expected.to be_invalid }
+      it { expect(mission.errors.messages[:ended_at]).to include error_message }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,5 +63,13 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
   config.include FactoryBot::Syntax::Methods
+
+  Shoulda::Matchers.configure do |c|
+    c.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
 end


### PR DESCRIPTION
## Added
 * Add gem `shoulda-matchers` for model specs (#15) (#30)
 * Add validation for model `Mission` (#15) (#30)
   * Add specs
   * Extend locales for model errors

## Changed
* Exclude rubocop `Metrics/BlockLength` check in model specs